### PR TITLE
Fix/debian deployment issues

### DIFF
--- a/roles/tier3-setup/tasks/debian-system.yml
+++ b/roles/tier3-setup/tasks/debian-system.yml
@@ -59,6 +59,14 @@
     creates: /etc/apt/sources.list.d/tailscale.list
   when: ansible_facts['distribution'] == 'Ubuntu'
   
+- name: Add Tailscale GPG Key (Debian)
+  shell: |
+    mkdir -p --mode=0755 /usr/share/keyrings
+    curl -fsSL https://pkgs.tailscale.com/stable/debian/$(lsb_release -cs).noarmor.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
+  args:
+    creates: /usr/share/keyrings/tailscale-archive-keyring.gpg
+  when: ansible_facts['distribution'] == 'Debian'
+
 - name: Add Tailscale Repository (Debian)
   shell: |
      curl -fsSL https://pkgs.tailscale.com/stable/debian/$(lsb_release -cs).tailscale-keyring.list | tee /etc/apt/sources.list.d/tailscale.list

--- a/roles/tier3-setup/tasks/debian-system.yml
+++ b/roles/tier3-setup/tasks/debian-system.yml
@@ -39,11 +39,10 @@
       - podman
     state: present
 
-- name: Install Podman Compose (via PIP)
-  pip:
+- name: Install Podman Compose (via APT)
+  apt:
     name: podman-compose
     state: present
-    executable: pip3
 
 # Tailscale Installation
 - name: Add Tailscale GPG Key

--- a/roles/tier3-setup/tasks/docker-deploy.yml
+++ b/roles/tier3-setup/tasks/docker-deploy.yml
@@ -60,8 +60,8 @@
 
 - name: Set Final Secrets
   set_fact:
-    litellm_key: "{{ existing_master_key if (existing_master_key | length > 0) else litellm_master_key_gen.stdout }}"
-    openclaw_token: "{{ existing_openclaw_token if (existing_openclaw_token | length > 0) else openclaw_token_gen.stdout }}"
+    litellm_key: "{{ existing_master_key if (existing_master_key | default('') | length > 0) else litellm_master_key_gen.stdout }}"
+    openclaw_token: "{{ existing_openclaw_token if (existing_openclaw_token | default('') | length > 0) else openclaw_token_gen.stdout }}"
 
 - name: Create .env file for Compose
   template:

--- a/roles/tier3-setup/templates/docker-compose.yml.j2
+++ b/roles/tier3-setup/templates/docker-compose.yml.j2
@@ -21,7 +21,7 @@ services:
     read_only: true
     tmpfs:
       - /tmp:rw,noexec,nosuid,size=100m
-    mem_limit: 512m
+    mem_limit: 1024m
     cpus: 1.0
 
   squid:


### PR DESCRIPTION
### podman compose installation
Apparently Debian 13 (and new versions of Ubuntu?) prevents system-wide pip installations, causing the podman compose installation in `debian-system.yml` to fail. Claude recommended changing it to use apt as in:

```
- name: Install Podman Compose
  apt:
    name: podman-compose
    state: present
```

and that worked.

### Tailscale GPG key task only runs on ubuntu
There's no Debian-equivalent task for adding the GPG key ring for Tailscale. Claude recommended the following just above the task for adding the tailscale repo for Debian, and it worked for me:

```
- name: Add Tailscale GPG Key (Debian)
  shell: |
    mkdir -p --mode=0755 /usr/share/keyrings
    curl -fsSL https://pkgs.tailscale.com/stable/debian/$(lsb_release -cs).noarmor.gpg | tee /usr/share/keyrings/tailscale-archive-keyring.gpg >/dev/null
  args:
    creates: /usr/share/keyrings/tailscale-archive-keyring.gpg
  when: ansible_facts['distribution'] == 'Debian'
```

### Bug in generating final secrets
Claude explains it best:

Here's what's happening. The flow:

1. "Check for existing secrets in .env" (line 35) → .env doesn't exist yet (first run) → fails → ignore_errors: true so it continues
2. "Extract Existing Master Key" (line 41) → skipped because existing_env_file.failed is true → existing_master_key never gets defined
3. "Generate LiteLLM Master Key" (line 51) → runs because existing_master_key | default('') | length == 0 evaluates correctly (the default('') filter saves it here)
4. "Set Final Secrets" (line 61) → tries to evaluate existing_master_key if (existing_master_key | length > 0) → crashes because there's no default() filter here, and existing_master_key is undefined

It's a bug in the playbook. The default('') guard is used on lines 54 and 59 but not on line 63-64. The fix is to add default('') in the "Set Final Secrets" task.

Edit `roles/tier3-setup/tasks/docker-deploy.yml`, replace lines 62-64:

```
  set_fact:
    litellm_key: "{{ existing_master_key if (existing_master_key | default('') | length > 0) else litellm_master_key_gen.stdout }}"
    openclaw_token: "{{ existing_openclaw_token if (existing_openclaw_token | default('') | length > 0) else openclaw_token_gen.stdout }}"
```

The only change on each line is existing_master_key | length → existing_master_key | default('') | length, and same for existing_openclaw_token. This way, on a fresh install where those variables were never set, it falls through to the generated values instead of crashing.

### Insufficient memory for LiteLLM
In `roles/tier3-setup/templates/docker-compose.yml.j2` the `mem_limit` for the `litellm` service is `512m`, but I found that it needed a little more and so kept crashing. I set it to `1024m` to be safe and that worked.